### PR TITLE
#256 - Remove share buttons from talent page when not logged in.

### DIFF
--- a/resources/views/layouts/partials/socialshare.blade.php
+++ b/resources/views/layouts/partials/socialshare.blade.php
@@ -1,6 +1,10 @@
-<div class="social-likes" style="margin: 10px 0;">
-    <h4>Share: </h4>
-    <div class="facebook" title="Share link on Facebook">Facebook</div>
-    <div class="twitter" title="Share link on Twitter">Twitter</div>
-    <div class="plusone" title="Share link on Google+">Google+</div>
-</div>
+@if (Auth::user())
+    <div class="social-likes" style="margin: 10px 0;">
+        <h4>Share: </h4>
+        <div class="facebook" title="Share link on Facebook">Facebook</div>
+        <div class="twitter" title="Share link on Twitter">Twitter</div>
+        <div class="plusone" title="Share link on Google+">Google+</div>
+    </div>
+@else
+    <div style="margin: 10px 0;">&nbsp;</div>
+@endif


### PR DESCRIPTION
#256 - Remove social share buttons from talent detail page when not logged in

![socialshare blade](https://cloud.githubusercontent.com/assets/943100/9641320/651b5cae-5173-11e5-9158-003424a3db6a.png)
Solution: Wrapped the social media share buttons in a conditional that checks if the user is logged in.
